### PR TITLE
#v2.1.2112.1-rc - Improve autoloading and assertions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,12 +28,12 @@
     },
     "autoload": {
         "psr-4": {
-            "": "src/"
+            "BitPaySDKLight\\": "src/BitPaySDKLight"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "BitPaySDKLight\\Test\\": "tests/"
+            "BitPaySDKLight\\Test\\": "tests/BitPaySDKLight"
         }
     }
 }

--- a/tests/BitPaySDKLight/BitPayTest.php
+++ b/tests/BitPaySDKLight/BitPayTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace BitPaySDKLight\Tests;
+namespace BitPaySDKLight\Test;
 
 
 use BitPaySDKLight;
@@ -319,7 +319,7 @@ class BitPayTest extends TestCase
             self::fail($e->getMessage());
         }
 
-        $this->assertTrue($rate != 0);
+        $this->assertNotEquals(0, $rate);
     }
 
     public function testShouldGetCNYExchangeRate()
@@ -333,7 +333,7 @@ class BitPayTest extends TestCase
             self::fail($e->getMessage());
         }
 
-        $this->assertTrue($rate != 0);
+        $this->assertNotEquals(0, $rate);
     }
 
     public function testShouldUpdateExchangeRates()


### PR DESCRIPTION
# Changed log

- Fixing the class autoloading for source and testing classes and let them be compatible with `PSR-4` autoloading.
- Using the `assertEquals` and `assertNotEquals` to replace equals operators with `assertTrue`.